### PR TITLE
Split macOS x86_64 and arm64 wheels as a fix for build errors on macos-14 runners with cibuildwheel 2.21.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
             artifact_suffix: "musllinux_s390x"
             use_qemu: true
           - os: macos-14
-            arch: "universal2"
+            arch: "arm64 x86_64"
             build: ""
             artifact_suffix: "macos"
             use_qemu: false
@@ -89,7 +89,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.21.1
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
-          CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_BUILD: "cp312-${{ matrix.build }}*"
 
       - uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,13 @@ if(WIN32)
   set(_tippecanoe_build_flags "${_tippecanoe_build_flags} -static -static-libgcc -static-libstdc++")
 endif()
 
-message(STATUS "CMAKE_OSX_ARCHITECTURES: ${CMAKE_OSX_ARCHITECTURES}")
+if(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
+  set(OSX_TARGET_FLAG "--target=x86_64-apple-macos10.9")
+elseif(CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+  set(OSX_TARGET_FLAG "--target=arm64-apple-macos11")
+else()
+  set(OSX_TARGET_FLAG "")
+endif()
 
 # tippecanoe
 set(TIPPECANOE_SOURCE_DIR ${CMAKE_BINARY_DIR}/TIPPECANOE-src)
@@ -45,7 +51,7 @@ ExternalProject_add(TIPPECANOE
   URL "https://github.com/felt/tippecanoe/archive/refs/tags/${TIPPECANOE_VERSION}.zip"
   # URL_HASH "SHA256="
   CONFIGURE_COMMAND ""
-  BUILD_COMMAND make -j
+  BUILD_COMMAND ${CMAKE_COMMAND} -E env CFLAGS="${OSX_TARGET_FLAG}" CXXFLAGS="${OSX_TARGET_FLAG}" make -j
   BUILD_IN_SOURCE ON
   INSTALL_COMMAND make -j install PREFIX=<INSTALL_DIR>
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ if(WIN32)
   set(_tippecanoe_build_flags "${_tippecanoe_build_flags} -static -static-libgcc -static-libstdc++")
 endif()
 
+message(STATUS "CMAKE_OSX_ARCHITECTURES: ${CMAKE_OSX_ARCHITECTURES}")
+
 # tippecanoe
 set(TIPPECANOE_SOURCE_DIR ${CMAKE_BINARY_DIR}/TIPPECANOE-src)
 set(TIPPECANOE_BINARY_DIR ${CMAKE_BINARY_DIR}/TIPPECANOE-build)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,17 +43,43 @@ endif()
 # tippecanoe
 set(TIPPECANOE_SOURCE_DIR ${CMAKE_BINARY_DIR}/TIPPECANOE-src)
 set(TIPPECANOE_BINARY_DIR ${CMAKE_BINARY_DIR}/TIPPECANOE-build)
+set(TIPPECANOE_URL "https://github.com/felt/tippecanoe/archive/refs/tags/${TIPPECANOE_VERSION}.zip")
 
 set(TIPPECANOE_INSTALL_DIR ${CMAKE_BINARY_DIR}/TIPPECANOE-install)
-ExternalProject_add(TIPPECANOE
-  SOURCE_DIR ${TIPPECANOE_SOURCE_DIR}
-  INSTALL_DIR ${TIPPECANOE_INSTALL_DIR}
-  URL "https://github.com/felt/tippecanoe/archive/refs/tags/${TIPPECANOE_VERSION}.zip"
-  # URL_HASH "SHA256="
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND ${CMAKE_COMMAND} -E env CFLAGS="${OSX_TARGET_FLAG}" CXXFLAGS="${OSX_TARGET_FLAG}" make -j
-  BUILD_IN_SOURCE ON
-  INSTALL_COMMAND make -j install PREFIX=<INSTALL_DIR>
-  )
+
+# Makefile based builds on macOS are weird and painful when cross-compiling...
+# Setting env vars was the only way that worked to get the a working --target option to the compiler
+if(APPLE)
+  if(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
+    set(OSX_TARGET_FLAG "--target=x86_64-apple-macos10.9")
+  elseif(CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
+    set(OSX_TARGET_FLAG "--target=arm64-apple-macos11")
+  else()
+    set(OSX_TARGET_FLAG "")
+  endif()
+  ExternalProject_add(TIPPECANOE
+    SOURCE_DIR ${TIPPECANOE_SOURCE_DIR}
+    INSTALL_DIR ${TIPPECANOE_INSTALL_DIR}
+    URL ${TIPPECANOE_URL}
+    # URL_HASH "SHA256="
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ${CMAKE_COMMAND} -E env CFLAGS="${OSX_TARGET_FLAG}" CXXFLAGS="${OSX_TARGET_FLAG}" make -j
+    BUILD_IN_SOURCE ON
+    INSTALL_COMMAND make -j install PREFIX=<INSTALL_DIR>
+    )
+else()
+  # But other OSes have issues building with overriding those env vars to be empty
+  ExternalProject_add(TIPPECANOE
+    SOURCE_DIR ${TIPPECANOE_SOURCE_DIR}
+    INSTALL_DIR ${TIPPECANOE_INSTALL_DIR}
+    URL ${TIPPECANOE_URL}
+    # URL_HASH "SHA256="
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND make -j
+    BUILD_IN_SOURCE ON
+    INSTALL_COMMAND make -j install PREFIX=<INSTALL_DIR>
+    )
+endif()
+
 install(PROGRAMS ${TIPPECANOE_INSTALL_DIR}/bin/ DESTINATION bin)
 install(FILES ${TIPPECANOE_INSTALL_DIR}/share/ DESTINATION share)


### PR DESCRIPTION
Just testing some changes to see if it makes the macOS build happy again.

Trying out building x86_64 and arm64 as separate wheels rather than universal2, since tippecanoe uses a Makefile. If that doesn't work, there are some CMakeLists.txt file changes that will pass a --target option using CFLAGS and CXXFLAGS.