### PR TITLE
Bump the macOS deployment target to 10.14 to use c++17 features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,7 @@ jobs:
           CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_BUILD: "cp312-${{ matrix.build }}*"
+          MACOSX_DEPLOYMENT_TARGET: "10.14"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ set(TIPPECANOE_INSTALL_DIR ${CMAKE_BINARY_DIR}/TIPPECANOE-install)
 # Setting env vars was the only way that worked to get the a working --target option to the compiler
 if(APPLE)
   if(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
-    set(OSX_TARGET_FLAG "--target=x86_64-apple-macos10.9")
+    set(OSX_TARGET_FLAG "--target=x86_64-apple-macos10.14")
   elseif(CMAKE_OSX_ARCHITECTURES STREQUAL "arm64")
     set(OSX_TARGET_FLAG "--target=arm64-apple-macos11")
   else()


### PR DESCRIPTION
Update the minimum target for macOS to 10.14, which allows full use of c++17 features.