### PR TITLE
Use QEMU v8 for emulated builds (#24)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.3.0
+        with:
+          image: tonistiigi/binfmt:qemu-v8.1.5
         if: runner.os == 'Linux' && matrix.use_qemu
 
       - name: Set up MSYS


### PR DESCRIPTION
QEMU v7 images that were being used constantly segfault after a recent update to the GitHub Actions Linux runner VMs.